### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/io.github.bytezz.IPLookup.json
+++ b/io.github.bytezz.IPLookup.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.bytezz.IPLookup",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "iplookup",
     "finish-args" : [
@@ -31,7 +31,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/Bytezz/IPLookup-gtk.git",
-                    "tag" : "v0.3.4"
+                    "commit" : "4651a4e63b8348d5da82fb4df422bf990092ab71"
                 }
             ]
         }


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.

Fixes: #16